### PR TITLE
Classify reads based on k-mer matches to coding and noncoding sequences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-name = "extract_kmers"
+name = "must"
 version = "0.1.0"
 authors = ["Olga Botvinnik <olga.botvinnik@gmail.com>"]
 edition = "2018"
 
 [dependencies]
 needletail = "^0.2.0"
-clap = "^2.33"
+clap = {version = "~2.32.0", features = ["yaml"]}
 lazy_static = "^1.3.0"
+exitfailure = "0.5.1"

--- a/src/classify_reads.rs
+++ b/src/classify_reads.rs
@@ -1,0 +1,131 @@
+use std::str;
+use std::collections::HashSet;
+extern crate lazy_static;
+extern crate needletail;
+use needletail::{fastx};
+extern crate clap;
+use clap::{Arg, App, value_t};
+
+use std::io::{self, BufReader};
+use std::io::prelude::*;
+use std::fs::File;
+
+fn read_kmer_file(kmer_file: str) {
+    let mut kmers = HashSet::new();
+
+    // Read in coding k-mers
+    let f = File::open(kmer_file)?;
+    let f = BufReader::new(f);
+
+    for line in f.lines() {
+        let kmer = line.unwrap();
+        kmers.insert(kmer.to_owned());
+    }
+    return kmers;
+}
+
+fn jaccardize(set1: HashSet, set2: HashSet, verbose: bool) -> f64 {
+    let denominator = min(set1.len(), set2.len());
+    if denominator > 0 {
+        numerator = set1.intersection(set2).len();
+        if verbose {
+            println("Number of overlapping k-mers: ", numerator, "out of", denominator)
+        }
+        return numerator/denominator;
+    } else {
+        return 0.0;
+    }
+}
+
+fn main() {
+    let matches = App::new("Classify reads as coding or non-coding")
+        .version("1.0")
+        .author("Olga Botvinnik <olga.botvinnik@czbiohub.org>")
+        .about("Classifies reads as coding or noncoding")
+        .arg(Arg::with_name("sequence_files")
+            .short("f")
+            .long("sequence_files")
+            .value_name("SEQUENCE_FILES")
+            .help("Input sequence files")
+            .required(true)
+            .multiple(true)
+            .takes_value(true))
+        .arg(Arg::with_name("coding_kmers")
+            .long("coding_kmers")
+            .value_name("CODING_KMERS")
+            .help("Plain text file of k-mers extracted from coding sequences (e.g. Homo_sapiens.GRCh38.cds.all.fa.gz )")
+            .required(true)
+            .takes_value(true))
+        .arg(Arg::with_name("noncoding_kmers")
+            .long("noncoding_kmers")
+            .value_name("noncoding_KMERS")
+            .help("Plain text file of k-mers extracted from noncoding sequences (e.g. Homo_sapiens.GRCh38.ncrna.fa.gz )")
+            .required(true)
+            .takes_value(true))
+        .arg(Arg::with_name("ksize")
+            .short("k")
+            .long("ksize")
+            .value_name("KSIZE")
+            .help("k-mer size")
+            // Clap currently only handles strings. Have to convert to int later
+            .default_value("21")
+            .takes_value(true))
+        .arg(Arg::with_name("v")
+            .short("v")
+            .multiple(true)
+            .help("Sets the level of verbosity"))
+        .get_matches();
+
+    // Vary the output based on how many times the user used the "verbose" flag
+    // (i.e. 'myprog -v -v -v' or 'myprog -vvv' vs 'myprog -v'
+    match matches.occurrences_of("v") {
+        0 => println!("No verbose info"),
+        1 => println!("Some verbose info"),
+        2 => println!("Tons of verbose info"),
+        3 | _ => println!("Don't be crazy"),
+    }
+
+    let sequence_files = matches.values_of("sequence_files").unwrap();
+    let coding_kmer_file = matches.value_of("coding_kmers").unwrap();
+    let noncoding_kmer_file = matches.value_of("noncoding_kmers").unwrap();
+
+    // Convert ksize string argument to integer
+    let ksize = value_t!(matches, "ksize", u8).unwrap_or_else(|e| e.exit());
+    let mut coding_kmers = read_kmer_file(coding_kmer_file);
+    let mut noncoding_kmers = read_kmer_file(noncoding_kmer_file);
+
+    for file in files {
+        eprintln!("Counting k-mers in file: {}", file);
+
+        let mut n_bases = 0;
+        fastx::fastx_cli(&file[..], |_| {}, |seq| {
+            let mut this_read_kmers = HashSet::new();
+            // seq.id is the name of the record
+            // seq.seq is the base sequence
+            // seq.qual is an optional quality score
+
+            // keep track of the total number of bases
+            n_bases += seq.seq.len();
+
+            // keep track of the number of AAAA (or TTTT via canonicalization) in the
+            // file (normalize makes sure every base is capitalized for comparison)
+            for (_, kmer, _) in seq.normalize(false).kmers(ksize, false) {
+                let kmer = str::from_utf8(&kmer).unwrap();
+                this_read_kmers.insert(kmer.to_owned());
+//            println!("{}", kmer);
+            }
+            let this_read_kmers_in_coding = coding_kmers.intersection(&this_read_kmers);
+            let this_read_kmers_in_noncoding = noncoding_kmers.intersection(&this_read_kmers);
+
+        }).expect(&format!("Could not read {}", file));
+
+
+        eprintln!("There are {} bases in your file.", n_bases);
+    }
+    eprintln!("There are {} k-mers in your file.", all_kmers.len());
+
+    for kmer in all_kmers {
+        println!("{}", kmer);
+    }
+
+}

--- a/src/classify_reads.rs
+++ b/src/classify_reads.rs
@@ -1,16 +1,15 @@
 use std::str;
+use std::cmp::min;
 use std::collections::HashSet;
 extern crate lazy_static;
 extern crate needletail;
 use needletail::{fastx};
-extern crate clap;
-use clap::{Arg, App, value_t};
 
-use std::io::{self, BufReader};
+use std::io::{BufReader};
 use std::io::prelude::*;
 use std::fs::File;
 
-fn read_kmer_file(kmer_file: str) {
+fn read_kmer_file(kmer_file: &str) -> HashSet<&'static str> {
     let mut kmers = HashSet::new();
 
     // Read in coding k-mers
@@ -24,12 +23,13 @@ fn read_kmer_file(kmer_file: str) {
     return kmers;
 }
 
-fn jaccardize(set1: HashSet, set2: HashSet, verbose: bool) -> f64 {
+fn jaccardize(set1: &HashSet<&str>, set2: &HashSet<&str>, verbose: usize) -> f64 {
     let denominator = min(set1.len(), set2.len());
     if denominator > 0 {
-        numerator = set1.intersection(set2).len();
+        let numerator = set1.intersection(&set2).len();
         if verbose {
-            println("Number of overlapping k-mers: ", numerator, "out of", denominator)
+            println!("Number of overlapping k-mers: {numerator}/{denominator}",
+                     numerator=numerator, denominator=denominator)
         }
         return numerator/denominator;
     } else {
@@ -37,65 +37,14 @@ fn jaccardize(set1: HashSet, set2: HashSet, verbose: bool) -> f64 {
     }
 }
 
-fn main() {
-    let matches = App::new("Classify reads as coding or non-coding")
-        .version("1.0")
-        .author("Olga Botvinnik <olga.botvinnik@czbiohub.org>")
-        .about("Classifies reads as coding or noncoding")
-        .arg(Arg::with_name("sequence_files")
-            .short("f")
-            .long("sequence_files")
-            .value_name("SEQUENCE_FILES")
-            .help("Input sequence files")
-            .required(true)
-            .multiple(true)
-            .takes_value(true))
-        .arg(Arg::with_name("coding_kmers")
-            .long("coding_kmers")
-            .value_name("CODING_KMERS")
-            .help("Plain text file of k-mers extracted from coding sequences (e.g. Homo_sapiens.GRCh38.cds.all.fa.gz )")
-            .required(true)
-            .takes_value(true))
-        .arg(Arg::with_name("noncoding_kmers")
-            .long("noncoding_kmers")
-            .value_name("noncoding_KMERS")
-            .help("Plain text file of k-mers extracted from noncoding sequences (e.g. Homo_sapiens.GRCh38.ncrna.fa.gz )")
-            .required(true)
-            .takes_value(true))
-        .arg(Arg::with_name("ksize")
-            .short("k")
-            .long("ksize")
-            .value_name("KSIZE")
-            .help("k-mer size")
-            // Clap currently only handles strings. Have to convert to int later
-            .default_value("21")
-            .takes_value(true))
-        .arg(Arg::with_name("v")
-            .short("v")
-            .multiple(true)
-            .help("Sets the level of verbosity"))
-        .get_matches();
+pub fn classify(sequence_files: Vec<&str>, coding_kmer_file: str,
+                non_coding_kmer_file: str, ksize: u8, verbosity: usize) {
+    let coding_kmers = read_kmer_file(&coding_kmer_file);
+    let non_coding_kmers = read_kmer_file(&non_coding_kmer_file);
+    let mut all_kmers = HashSet::new();
 
-    // Vary the output based on how many times the user used the "verbose" flag
-    // (i.e. 'myprog -v -v -v' or 'myprog -vvv' vs 'myprog -v'
-    match matches.occurrences_of("v") {
-        0 => println!("No verbose info"),
-        1 => println!("Some verbose info"),
-        2 => println!("Tons of verbose info"),
-        3 | _ => println!("Don't be crazy"),
-    }
-
-    let sequence_files = matches.values_of("sequence_files").unwrap();
-    let coding_kmer_file = matches.value_of("coding_kmers").unwrap();
-    let noncoding_kmer_file = matches.value_of("noncoding_kmers").unwrap();
-
-    // Convert ksize string argument to integer
-    let ksize = value_t!(matches, "ksize", u8).unwrap_or_else(|e| e.exit());
-    let mut coding_kmers = read_kmer_file(coding_kmer_file);
-    let mut noncoding_kmers = read_kmer_file(noncoding_kmer_file);
-
-    for file in files {
-        eprintln!("Counting k-mers in file: {}", file);
+    for file in sequence_files {
+        eprintln!("Classifying reads in file: {}", file);
 
         let mut n_bases = 0;
         fastx::fastx_cli(&file[..], |_| {}, |seq| {
@@ -112,10 +61,17 @@ fn main() {
             for (_, kmer, _) in seq.normalize(false).kmers(ksize, false) {
                 let kmer = str::from_utf8(&kmer).unwrap();
                 this_read_kmers.insert(kmer.to_owned());
+                all_kmers.insert(kmer.to_owned());
 //            println!("{}", kmer);
             }
             let this_read_kmers_in_coding = coding_kmers.intersection(&this_read_kmers);
-            let this_read_kmers_in_noncoding = noncoding_kmers.intersection(&this_read_kmers);
+            let this_read_kmers_in_noncoding = non_coding_kmers.intersection(&this_read_kmers);
+            let jaccard_coding = jaccardize(&this_read_kmers, &coding_kmers, verbosity);
+            let jaccard_non_coding = jaccardize(&this_read_kmers, &non_coding_kmers, verbosity);
+            if verbosity > 0 {
+                println!("{seq} jaccard with coding: {jaccard}", seq=seq.id, jaccard=jaccard_coding);
+                println!("{seq} jaccard with non coding: {jaccard}", seq=seq.id, jaccard=jaccard_non_coding);
+            }
 
         }).expect(&format!("Could not read {}", file));
 
@@ -123,9 +79,5 @@ fn main() {
         eprintln!("There are {} bases in your file.", n_bases);
     }
     eprintln!("There are {} k-mers in your file.", all_kmers.len());
-
-    for kmer in all_kmers {
-        println!("{}", kmer);
-    }
 
 }

--- a/src/complement_table.rs
+++ b/src/complement_table.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+
+#[inline]
+pub fn complement(n: &u8) -> u8 {
+    //! Returns the complementary base for a given IUPAC base code.
+    //!
+    //! Does not work for RNA sequences (maybe we should raise an error or something?)
+    match *n as char {
+        'a' => 't' as u8, 'A' => 'T' as u8,
+        'c' => 'g' as u8, 'C' => 'G' as u8,
+        'g' => 'c' as u8, 'G' => 'C' as u8,
+        't' => 'a' as u8, 'T' => 'A' as u8,
+
+        // IUPAC codes
+        'r' => 'y' as u8, 'y' => 'r' as u8,
+        'k' => 'm' as u8, 'm' => 'k' as u8,
+        'b' => 'v' as u8, 'v' => 'b' as u8,
+        'd' => 'h' as u8, 'h' => 'd' as u8,
+        's' => 's' as u8, 'w' => 'w' as u8,
+        'R' => 'Y' as u8, 'Y' => 'R' as u8,
+        'K' => 'M' as u8, 'M' => 'K' as u8,
+        'B' => 'V' as u8, 'V' => 'B' as u8,
+        'D' => 'H' as u8, 'H' => 'D' as u8,
+        'S' => 'S' as u8, 'W' => 'W' as u8,
+
+        // anything else just pass through
+        // 'u' | 'U' => panic!("Does not support complements of U"),
+        x => x as u8,
+    }
+}

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,0 +1,46 @@
+use std::str;
+use std::collections::HashSet;
+extern crate lazy_static;
+extern crate needletail;
+use needletail::{fastx};
+
+
+// Local code
+//mod codon_table;
+//mod complement_table;
+
+pub fn extract_kmers(sequence_files: Vec<&str>, ksize: u8) {
+
+    let mut all_kmers = HashSet::new();
+
+
+    for sequence_file in sequence_files {
+        eprintln!("Counting k-mers in file: {}", sequence_file);
+
+        let mut n_bases = 0;
+        fastx::fastx_cli(&sequence_file[..], |_| {}, |seq| {
+// seq.id is the name of the record
+// seq.seq is the base sequence
+// seq.qual is an optional quality score
+
+// keep track of the total number of bases
+            n_bases += seq.seq.len();
+
+// keep track of the number of AAAA (or TTTT via canonicalization) in the
+// file (normalize makes sure every base is capitalized for comparison)
+            for (_, kmer, _) in seq.normalize(false).kmers(ksize, false) {
+                let kmer = str::from_utf8(&kmer).unwrap();
+                all_kmers.insert(kmer.to_owned());
+//            println!("{}", kmer);
+            }
+        }).expect(&format!("Could not read {}", sequence_file));
+
+
+        eprintln!("There are {} bases in your file.", n_bases);
+    }
+    eprintln!("There are {} k-mers in your file.", all_kmers.len());
+
+    for kmer in all_kmers {
+        println!("{}", kmer);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,22 @@ extern crate clap;
 use clap::{App, load_yaml, value_t};
 
 mod extract;
+mod classify_reads;
 
 fn main() -> Result<(), ExitFailure> {
 
     let yml = load_yaml!("must.yml");
     let m = App::from_yaml(yml).get_matches();
+
+    // Vary the output based on how many times the user used the "verbose" flag
+    // (i.e. 'myprog -v -v -v' or 'myprog -vvv' vs 'myprog -v'
+    match m.occurrences_of("v") {
+        0 => println!("No verbose info"),
+        1 => println!("Some verbose info"),
+        2 => println!("Tons of verbose info"),
+        3 | _ => println!("Don't be crazy"),
+    }
+    let verbosity = m.occurrences_of("v");
 
     match m.subcommand_name() {
         Some("extract") => {
@@ -22,6 +33,27 @@ fn main() -> Result<(), ExitFailure> {
             // Convert ksize string argument to integer
             let ksize: u8 = value_t!(cmd, "ksize", u8).unwrap_or_else(|e| e.exit());
             extract::extract_kmers(sequence_files, ksize);
+        }
+        Some("classify") => {
+            let cmd = m.subcommand_matches("compute").unwrap();
+            let sequence_files = cmd
+                .values_of("sequence_files")
+                .map(|vals| vals.collect::<Vec<_>>())
+                .unwrap();
+
+            // Convert ksize string argument to integer
+            let ksize: u8 = value_t!(cmd, "ksize", u8).unwrap_or_else(|e| e.exit());
+
+            let coding_kmer_file = cmd.value_of("coding_kmers").unwrap();
+            let non_coding_kmer_file = cmd.value_of("noncoding_kmers").unwrap();
+
+            // Convert ksize string argument to integer
+            let ksize: u8 = value_t!(cmd, "ksize", u8).unwrap_or_else(|e| e.exit());
+
+            classify_reads::classify(sequence_files,
+                                     coding_kmer_file,
+                                     non_coding_kmer_file,
+                                     ksize, verbosity);
         }
         _ => {
             println!("{:?}", m);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,73 +1,31 @@
-use std::str;
-use std::collections::HashSet;
 extern crate lazy_static;
 extern crate needletail;
-use needletail::{fastx};
+use exitfailure::ExitFailure;
 extern crate clap;
-use clap::{Arg, App, value_t};
+use clap::{App, load_yaml, value_t};
 
-// Local code
-mod codon_table;
-mod complement_table;
+mod extract;
 
-fn main() {
-    let matches = App::new("My Super Program")
-        .version("1.0")
-        .author("Olga Botvinnik <olga.botvinnik@czbiohub.org>")
-        .about("Does awesome things")
-        .arg(Arg::with_name("files")
-            .short("f")
-            .long("files")
-            .value_name("FILES")
-            .help("Input sequence file")
-            .required(true)
-            .multiple(true)
-            .takes_value(true))
-        .arg(Arg::with_name("ksize")
-            .short("k")
-            .long("ksize")
-            .value_name("KSIZE")
-            .help("k-mer size")
-            // Clap currently only handles strings. Have to convert to int later
-            .default_value("21")
-            .takes_value(true))
-        .get_matches();
+fn main() -> Result<(), ExitFailure> {
 
-    let files = matches.values_of("files").unwrap();
+    let yml = load_yaml!("must.yml");
+    let m = App::from_yaml(yml).get_matches();
 
-    // Convert ksize string argument to integer
-    let ksize = value_t!(matches, "ksize", u8).unwrap_or_else(|e| e.exit());
-    let mut all_kmers = HashSet::new();
+    match m.subcommand_name() {
+        Some("extract") => {
+            let cmd = m.subcommand_matches("compute").unwrap();
+            let sequence_files = cmd
+                .values_of("sequence_files")
+                .map(|vals| vals.collect::<Vec<_>>())
+                .unwrap();
 
-
-    for file in files {
-        eprintln!("Counting k-mers in file: {}", file);
-
-        let mut n_bases = 0;
-        fastx::fastx_cli(&file[..], |_| {}, |seq| {
-        // seq.id is the name of the record
-        // seq.seq is the base sequence
-        // seq.qual is an optional quality score
-
-        // keep track of the total number of bases
-        n_bases += seq.seq.len();
-
-        // keep track of the number of AAAA (or TTTT via canonicalization) in the
-        // file (normalize makes sure every base is capitalized for comparison)
-        for (_, kmer, _) in seq.normalize(false).kmers(ksize, false) {
-            let kmer = str::from_utf8(&kmer).unwrap();
-            all_kmers.insert(kmer.to_owned());
-//            println!("{}", kmer);
+            // Convert ksize string argument to integer
+            let ksize: u8 = value_t!(cmd, "ksize", u8).unwrap_or_else(|e| e.exit());
+            extract::extract_kmers(sequence_files, ksize);
         }
-        }).expect(&format!("Could not read {}", file));
-
-
-        eprintln!("There are {} bases in your file.", n_bases);
+        _ => {
+            println!("{:?}", m);
+        }
     }
-    eprintln!("There are {} k-mers in your file.", all_kmers.len());
-
-    for kmer in all_kmers {
-        println!("{}", kmer);
-    }
-
+    Ok(())
 }

--- a/src/must.yml
+++ b/src/must.yml
@@ -1,0 +1,41 @@
+name: must
+version: "0.0.1"
+about: "must commands"
+author: Olga Botvinnik <olga.botvinnik@czbiohub.org>
+
+settings:
+    - SubcommandRequiredElseHelp
+
+subcommands:
+    - extract:
+        about: Extract k-mers of specific size
+        settings:
+            - ArgRequiredElseHelp
+        args:
+            - ksize:
+                help: ksize
+                short: K
+                default_value: "21"
+                takes_value: true
+                required: false
+            - sequence_files:
+                help: FASTA/FASTQ files
+                multiple: true
+    - classify:
+        about: Classify reads as coding or noncoding
+        settings:
+            - ArgRequiredElseHelp
+        args:
+            - ksize:
+                help: ksize
+                short: K
+                default_value: "21"
+                takes_value: true
+                required: false
+            - coding_kmers:
+                help: Plain text file of k-mers extracted from coding sequences, e.g. from a file like Homo_sapiens.GRCh38.cds.all.fa.gz
+            - non_coding_kmers:
+                help: Plain text file of k-mers extracted from non-coding sequences, e.g. from a file like Homo_sapiens.GRCh38.ncrna.all.fa.gz
+            - sequence_files:
+                help: FASTA/FASTQ files
+                multiple: true

--- a/src/must.yml
+++ b/src/must.yml
@@ -5,6 +5,11 @@ author: Olga Botvinnik <olga.botvinnik@czbiohub.org>
 
 settings:
     - SubcommandRequiredElseHelp
+args:
+    - verbose:
+        short: v
+        multiple: true
+        help: Sets the level of verbosity
 
 subcommands:
     - extract:
@@ -21,6 +26,7 @@ subcommands:
             - sequence_files:
                 help: FASTA/FASTQ files
                 multiple: true
+                required: true
     - classify:
         about: Classify reads as coding or noncoding
         settings:
@@ -34,8 +40,11 @@ subcommands:
                 required: false
             - coding_kmers:
                 help: Plain text file of k-mers extracted from coding sequences, e.g. from a file like Homo_sapiens.GRCh38.cds.all.fa.gz
+                required: true
             - non_coding_kmers:
                 help: Plain text file of k-mers extracted from non-coding sequences, e.g. from a file like Homo_sapiens.GRCh38.ncrna.all.fa.gz
+                required: true
             - sequence_files:
                 help: FASTA/FASTQ files
                 multiple: true
+                required: true


### PR DESCRIPTION
I'm probably doing this wrong but this depends on https://github.com/czbiohub/extract_kmers/pull/3

- Big refactor to move subcommands into separate files

Currently getting a lot of type safety errors like strings vs pointers and `u8` vs `usize` .. could definitely use some help.

<details>

```
(base)
 ♥ 82%  Mon  9 Sep - 12:20  ~/code/kmer-hashing/extract_kmers   origin ☊ olgabot/classify-reads ✔ 14☀ 
  make test
cargo run -- --files test-data/*.fasta
   Compiling must v0.1.0 (/Users/olgabot/code/kmer-hashing/extract_kmers)
error[E0308]: mismatched types
  --> src/main.rs:54:38
   |
54 |                                      coding_kmer_file,
   |                                      ^^^^^^^^^^^^^^^^ expected str, found &str
   |
   = note: expected type `str`
              found type `&str`

error[E0308]: mismatched types
  --> src/main.rs:55:38
   |
55 |                                      non_coding_kmer_file,
   |                                      ^^^^^^^^^^^^^^^^^^^^ expected str, found &str
   |
   = note: expected type `str`
              found type `&str`

error[E0308]: mismatched types
  --> src/main.rs:56:45
   |
56 |                                      ksize, verbosity);
   |                                             ^^^^^^^^^ expected usize, found u64

error[E0277]: the size for values of type `str` cannot be known at compilation time
  --> src/main.rs:53:13
   |
53 |             classify_reads::classify(sequence_files,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
   |
   = help: the trait `std::marker::Sized` is not implemented for `str`
   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
   = note: all function arguments must have a statically known size
   = help: unsized locals are gated as an unstable feature

error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
  --> src/classify_reads.rs:16:13
   |
16 |     let f = File::open(kmer_file)?;
   |             ^^^^^^^^^^^^^^^^^^^^^^ cannot use the `?` operator in a function that returns `std::collections::HashSet<&str>`
   |
   = help: the trait `std::ops::Try` is not implemented for `std::collections::HashSet<&str>`
   = note: required by `std::ops::Try::from_error`

error[E0308]: mismatched types
  --> src/classify_reads.rs:23:12
   |
23 |     return kmers;
   |            ^^^^^ expected reference, found struct `std::string::String`
   |
   = note: expected type `std::collections::HashSet<&'static str>`
              found type `std::collections::HashSet<std::string::String>`

error[E0599]: no method named `len` found for type `std::collections::hash_set::Intersection<'_, &str, std::collections::hash_map::RandomState>` in the current scope
  --> src/classify_reads.rs:29:50
   |
29 |         let numerator = set1.intersection(&set2).len();
   |                                                  ^^^

error[E0308]: mismatched types
  --> src/classify_reads.rs:30:12
   |
30 |         if verbose {
   |            ^^^^^^^ expected bool, found usize

error[E0277]: the size for values of type `str` cannot be known at compilation time
  --> src/classify_reads.rs:40:44
   |
40 | pub fn classify(sequence_files: Vec<&str>, coding_kmer_file: str,
   |                                            ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
   |
   = help: the trait `std::marker::Sized` is not implemented for `str`
   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
   = note: all local variables must have a statically known size
   = help: unsized locals are gated as an unstable feature

error[E0277]: the size for values of type `str` cannot be known at compilation time
  --> src/classify_reads.rs:41:17
   |
41 |                 non_coding_kmer_file: str, ksize: u8, verbosity: usize) {
   |                 ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
   |
   = help: the trait `std::marker::Sized` is not implemented for `str`
   = note: to learn more, visit <https://doc.rust-lang.org/book/second-edition/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
   = note: all local variables must have a statically known size
   = help: unsized locals are gated as an unstable feature

error[E0308]: mismatched types
  --> src/classify_reads.rs:67:71
   |
67 |             let this_read_kmers_in_coding = coding_kmers.intersection(&this_read_kmers);
   |                                                                       ^^^^^^^^^^^^^^^^ expected &str, found struct `std::string::String`
   |
   = note: expected type `&std::collections::HashSet<&str>`
              found type `&std::collections::HashSet<std::string::String>`

error[E0308]: mismatched types
  --> src/classify_reads.rs:68:78
   |
68 |             let this_read_kmers_in_noncoding = non_coding_kmers.intersection(&this_read_kmers);
   |                                                                              ^^^^^^^^^^^^^^^^ expected &str, found struct `std::string::String`
   |
   = note: expected type `&std::collections::HashSet<&str>`
              found type `&std::collections::HashSet<std::string::String>`

error[E0308]: mismatched types
  --> src/classify_reads.rs:69:45
   |
69 |             let jaccard_coding = jaccardize(&this_read_kmers, &coding_kmers, verbosity);
   |                                             ^^^^^^^^^^^^^^^^ expected &str, found struct `std::string::String`
   |
   = note: expected type `&std::collections::HashSet<&str>`
              found type `&std::collections::HashSet<std::string::String>`

error[E0308]: mismatched types
  --> src/classify_reads.rs:70:49
   |
70 |             let jaccard_non_coding = jaccardize(&this_read_kmers, &non_coding_kmers, verbosity);
   |                                                 ^^^^^^^^^^^^^^^^ expected &str, found struct `std::string::String`
   |
   = note: expected type `&std::collections::HashSet<&str>`
              found type `&std::collections::HashSet<std::string::String>`

error: aborting due to 14 previous errors

Some errors occurred: E0277, E0308, E0599.
For more information about an error, try `rustc --explain E0277`.
error: Could not compile `must`.

To learn more, run the command again with --verbose.
make: *** [test] Error 101
```

</details>