### PR TITLE
Update needletail to v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Olga Botvinnik <olga.botvinnik@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-needletail = "^0.2.0"
+needletail = "^0.3.0"
 clap = "^2.33"
 lazy_static = "^1.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::str;
 use std::collections::HashSet;
 extern crate lazy_static;
 extern crate needletail;
-use needletail::{fastx};
+use needletail::{parse_sequence_path, Sequence};
 extern crate clap;
 use clap::{Arg, App, value_t};
 
@@ -43,7 +43,7 @@ fn main() {
         eprintln!("Counting k-mers in file: {}", file);
 
         let mut n_bases = 0;
-        fastx::fastx_cli(&file[..], |_| {}, |seq| {
+        parse_sequence_path(file, |_| {}, |seq| {
         // seq.id is the name of the record
         // seq.seq is the base sequence
         // seq.qual is an optional quality score
@@ -53,7 +53,7 @@ fn main() {
 
         // keep track of the number of AAAA (or TTTT via canonicalization) in the
         // file (normalize makes sure every base is capitalized for comparison)
-        for (_, kmer, _) in seq.normalize(false).kmers(ksize, false) {
+        for kmer in seq.kmers(ksize) {
             let kmer = str::from_utf8(&kmer).unwrap();
             all_kmers.insert(kmer.to_owned());
 //            println!("{}", kmer);


### PR DESCRIPTION
Hopefully this resolves some of the issues you've had with needletail parsing amino acids sequences improperly (as in #7 ).

Note that this is no longer using `.normalize(...)` on the records/sequences because that will improperly coerce amino acid residues; if you still need to handle upper/lowercase residues, you may want to change your `kmer.to_owned()` to `kmer.to_uppercase()`.

And please let me know if there are any issues, questions, or if there's anything else I can help with.